### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Custom [Newman](https://github.com/postmanlabs/newman) reporter to send message 
 
 ## Installation
  ```CLI
- npm run i -g newman-reporter-slackmsg
+ npm i -g newman-reporter-slackmsg
  ```
 
 ## Usage
  ```CLI
- newman run <collectionFile> -e <environmentFile> --suppress-exit-code -r slackmsg --reporter-slack-webhookurl '<webhookurl>'
+ newman run <collectionFile> -e <environmentFile> --suppress-exit-code -r slackmsg --reporter-slackmsg-webhookurl '<webhookurl>'
  ```
 
 ## Contributing


### PR DESCRIPTION
Fixed issues on *Readme* with incorrect installation and usage commands:

Fixed Installation command issue:
`ENOENT: no such file or directory, open 'package.json'`

Fixed Usage command issue:
`Error in sending message to slack TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received type undefined`