### PR TITLE
Slack now borks with 400 for invalid JSON

### DIFF
--- a/slackUtils.js
+++ b/slackUtils.js
@@ -191,23 +191,20 @@ function parseFailures(failures) {
 
 // Takes parsedFailures and create failMessages
 function failMessage(parsedFailures) {
-    const failures = parsedFailures.reduce((acc, failure) => {
-        acc.push(`
+    return parsedFailures.map((failure) => {
+        return `
         {
             "title": "${failure.name}",
             "short": false
         },
-        ${failErrors(failure.tests)}`)
-        return acc;
-    }, []);
-
-    return failures.join()
+        ${failErrors(failure.tests)}`;
+    }).join();
 }
 
 // Takes failMessages and create Error messages for each failures
 function failErrors(parsedErrors) {
-    const errors = parsedErrors.reduce((acc, error, index) => {
-        acc.push(`
+    return parsedErrors.map((error, index) => {
+        return `
         {
             "value": "*\`${index + 1}. ${error.name} - ${error.test}\`*",
             "short": false
@@ -215,11 +212,8 @@ function failErrors(parsedErrors) {
         {
             "value": "• ${cleanErrorMessage(error.message, messageSize)}",
             "short": false
-        }`);
-        return acc;
-    }, []);
-
-    return errors.join()
+        }`;
+    }).join();
 }
 
 function cleanErrorMessage(message, maxMessageSize) {

--- a/slackUtils.js
+++ b/slackUtils.js
@@ -20,7 +20,7 @@ function slackMessage(stats, timings, failures, executions, maxMessageSize, coll
                 ${failMessage(parsedFailures)}
             ],
             "footer": "Newman Test",
-            "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
+            "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png"
         }
     ]`
     let successMessage = `
@@ -31,7 +31,7 @@ function slackMessage(stats, timings, failures, executions, maxMessageSize, coll
             "author_name": "Newman Tests",
             "title": ":white_check_mark: All Passed :white_check_mark:",
             "footer": "Newman Test",
-            "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
+            "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png"
         }
     ]`
     return jsonminify(`
@@ -95,8 +95,8 @@ function slackMessage(stats, timings, failures, executions, maxMessageSize, coll
                     {
                         "type": "mrkdwn",
                         "text": "${prettyms(timings.completed - timings.started)}"
-                    },
-                ],
+                    }
+                ]
             },
             {
                 "type": "section",
@@ -108,12 +108,12 @@ function slackMessage(stats, timings, failures, executions, maxMessageSize, coll
                 {
                     "type": "mrkdwn",
                     "text": "Total: ${stats.assertions.total}  Failed: ${stats.assertions.failed}"
-                },
+                }
             ]
             },
             {
                 "type": "divider"
-            },
+            }
         ],
         ${failures.length > 0 ? failureMessage : successMessage}
        }`);

--- a/slackUtils.js
+++ b/slackUtils.js
@@ -191,31 +191,35 @@ function parseFailures(failures) {
 
 // Takes parsedFailures and create failMessages
 function failMessage(parsedFailures) {
-    return parsedFailures.reduce((acc, failure) => {
-        acc = acc + `
+    const failures = parsedFailures.reduce((acc, failure) => {
+        acc.push(`
         {
             "title": "${failure.name}",
             "short": false
         },
-        ${failErrors(failure.tests)}`
+        ${failErrors(failure.tests)}`)
         return acc;
-    }, '');
+    }, []);
+
+    return failures.join()
 }
 
 // Takes failMessages and create Error messages for each failures
 function failErrors(parsedErrors) {
-    return parsedErrors.reduce((acc, error, index) => {
-        acc = acc + `
+    const errors = parsedErrors.reduce((acc, error, index) => {
+        acc.push(`
         {
             "value": "*\`${index + 1}. ${error.name} - ${error.test}\`*",
             "short": false
         },
         {
             "value": "• ${cleanErrorMessage(error.message, messageSize)}",
-            "short": false,
-        },`;
+            "short": false
+        }`);
         return acc;
-    }, '');
+    }, []);
+
+    return errors.join()
 }
 
 function cleanErrorMessage(message, maxMessageSize) {


### PR DESCRIPTION
Slack now returns a `400` if the `JSON` is invalid. Removing the trailing commas fixes the issue. Unfortunately `jsonminify` only appears to remove whitespaces and comments. I can only assume this stopped working after new validations being introduced on Slack API (stopped working at the 3rd of September).

<img width="571" alt="Screenshot 2021-09-07 at 16 12 08" src="https://user-images.githubusercontent.com/678939/132369009-533f0574-8331-4bbd-906e-7566118b7018.png">

**Message before this fix**

```
{
  "channel":  "#my-channel",
  "blocks": [
    {
      "type": "divider"
    },
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "*Test Summary*"
      }
    },
    {
      "type": "section",
      "fields": [
        {
          "type": "mrkdwn",
          "text": "Total Tests:"
        },
        {
          "type": "mrkdwn",
          "text": "4"
        },
        {
          "type": "mrkdwn",
          "text": "Test Passed:"
        },
        {
          "type": "mrkdwn",
          "text": "4"
        },
        {
          "type": "mrkdwn",
          "text": "Test Failed:"
        },
        {
          "type": "mrkdwn",
          "text": "0"
        },
        {
          "type": "mrkdwn",
          "text": "Test Skipped:"
        },
        {
          "type": "mrkdwn",
          "text": "0"
        },
        {
          "type": "mrkdwn",
          "text": "Test Duration:"
        },
        {
          "type": "mrkdwn",
          "text":"1.6s"
        },
      ],
    },
    {
      "type": "section",
      "fields": [
        {
          "type": "mrkdwn",
          "text": "Assertions:"
        },
        {
          "type": "mrkdwn",
          "text": "Total: 10  Failed: 0"
        },
      ]
    },
    {
      "type": "divider"
    },
  ],
  "attachments": [
    {
      "mrkdwn_in": ["text"],
      "color": "#008000",
      "author_name": "Newman Tests",
      "title": ":white_check_mark: All Passed :white_check_mark:",
      "footer": "Newman Test",
      "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
    }
  ]
}
```

**Message after this fix**

```
{
  "channel": "#my-channel",
  "blocks": [
    {
      "type": "divider"
    },
    {
      "type": "divider"
    },
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "*Test Summary*"
      }
    },
    {
      "type": "section",
      "fields": [
        {
          "type": "mrkdwn",
          "text": "Total Tests:"
        },
        {
          "type": "mrkdwn",
          "text": "4"
        },
        {
          "type": "mrkdwn",
          "text": "Test Passed:"
        },
        {
          "type": "mrkdwn",
          "text": "4"
        },
        {
          "type": "mrkdwn",
          "text": "Test Failed:"
        },
        {
          "type": "mrkdwn",
          "text": "0"
        },
        {
          "type": "mrkdwn",
          "text": "Test Skipped:"
        },
        {
          "type": "mrkdwn",
          "text": "0"
        },
        {
          "type": "mrkdwn",
          "text": "Test Duration:"
        },
        {
          "type": "mrkdwn",
          "text": "2.2s"
        }
      ]
    },
    {
      "type": "section",
      "fields": [
        {
          "type": "mrkdwn",
          "text": "Assertions:"
        },
        {
          "type": "mrkdwn",
          "text": "Total: 10  Failed: 0"
        }
      ]
    },
    {
      "type": "divider"
    }
  ],
  "attachments": [
    {
      "mrkdwn_in": [
        "text"
      ],
      "color": "#008000",
      "author_name": "Newman Tests",
      "title": ":white_check_mark: All Passed :white_check_mark:",
      "footer": "Newman Test",
      "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png"
    }
  ]
}
```