### PR TITLE
feat: authorName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ or
  --reporter-slackmsg-collection '<collectionName> e.g test.json
  --reporter-slackmsg-environment '<environmentName> e.g env.json
  --reporter-slackmsg-reportingurl '<URL> e.g https://127.0.1/index.html
-  --reporter-slackmsg-limitFailures '<limitFailures>; e.g 5
+ --reporter-slackmsg-limitFailures '<limitFailures>; e.g 5
+ --reporter-slackmsg-authorName '<authorName>; e.g "Newman Test"
 
 ```
 
@@ -64,3 +65,6 @@ Option to select channel or user to receive failures
 **limitFailures**
 Option to limit the amount failures shown in slack
 
+**authorName**
+
+Option to define a custom author name for Slack's message. If not provided, “Newman Test” will be used.

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function SlackNewmanReporter(emitter, reporterOptions) {
     const reportingUrl = reporterOptions.reportingurl || '';
     let channel = reporterOptions.channel || '';
     let limitFailures = reporterOptions.limitFailures || null;
+    const authorName = reporterOptions.authorName || '';
 
 
     emitter.on('done', (error, summary) => {
@@ -27,7 +28,7 @@ function SlackNewmanReporter(emitter, reporterOptions) {
             channel = reporterOptions.failuresChannel;
         }
 
-        slackUtils.send(webhookUrl, slackUtils.slackMessage(run.stats, run.timings, run.failures, run.executions, messageSize, collection, environment, channel, reportingUrl, limitFailures), token);
+        slackUtils.send(webhookUrl, slackUtils.slackMessage(run.stats, run.timings, run.failures, run.executions, messageSize, collection, environment, channel, reportingUrl, limitFailures, authorName), token);
     });
 
     function missingReporterOptions(reporterOptions) {

--- a/slackUtils.js
+++ b/slackUtils.js
@@ -5,16 +5,17 @@ var jsonminify = require("jsonminify");
 let messageSize;
 
 // creates message for slack
-function slackMessage(stats, timings, failures, executions, maxMessageSize, collection, environment, channel, reportingUrl, limitFailures) {
+function slackMessage(stats, timings, failures, executions, maxMessageSize, collection, environment, channel, reportingUrl, limitFailures, authorName) {
     messageSize = maxMessageSize;
     let parsedFailures = parseFailures(failures);
     let skipCount = getSkipCount(executions);
+    let author = authorName || 'Newman Test';
     let failureMessage = `
     "attachments": [
         {
             "mrkdwn_in": ["text"],
             "color": "#FF0000",
-            "author_name": "Newman Tests",
+            "author_name": "${author}",
             "title": ":fire: Failures :fire:",
             "fields": [
                 ${limitFailures > 0 ? failMessage(parsedFailures.splice(0, limitFailures)) : failMessage(parsedFailures)}
@@ -28,7 +29,7 @@ function slackMessage(stats, timings, failures, executions, maxMessageSize, coll
         {
             "mrkdwn_in": ["text"],
             "color": "#008000",
-            "author_name": "Newman Tests",
+            "author_name": "${author}",
             "title": ":white_check_mark: All Passed :white_check_mark:",
             "footer": "Newman Test",
             "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,7 +50,7 @@ describe('SlackNewmanReporter', () => {
         mockEmitter.emit('done', '', summary);
 
         expect(slackUtils.send).toHaveBeenCalled();
-        expect(slackUtils.slackMessage).toBeCalledWith(...['', {}, summary.run.failures, undefined, 100, '', '', failuresChannel, '', null]);
+        expect(slackUtils.slackMessage).toBeCalledWith(...['', {}, summary.run.failures, undefined, 100, '', '', failuresChannel, '', null, '']);
     });
 
     test('should start slack reporter given no errors for webhook', () => {
@@ -72,6 +72,17 @@ describe('SlackNewmanReporter', () => {
 
         expect(slackUtils.send).toHaveBeenCalled();
         expect(slackUtils.slackMessage).toHaveBeenCalled();
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    test('should start slack reporter given no errors for author name override', () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+
+        slackNewmanReporter(mockEmitter, {webhookurl: 'test', authorName: 'John Doe'}, {});
+        mockEmitter.emit('done', '', summary);
+
+        expect(slackUtils.send).toHaveBeenCalled();
+        expect(slackUtils.slackMessage).toBeCalledWith(...['', {}, summary.run.failures, undefined, 100, '', '', '', '', null, 'John Doe']);
         expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 

--- a/test/slackUtils.test.js
+++ b/test/slackUtils.test.js
@@ -130,6 +130,7 @@ describe('slackUtils', () => {
             // should include channel name if given for channel override
             expect(result).toContain(`"channel":"#general"`);
             // successful message 
+            expect(result).toContain(`Newman Test`);
             expect(result).toContain(`{"type":"mrkdwn","text":"Total Tests:"},{"type":"mrkdwn","text":"4"}`);
             expect(result).toContain(`{"type":"mrkdwn","text":"Test Passed:"},{"type":"mrkdwn","text":"3"}`);
             expect(result).toContain(`{"type":"mrkdwn","text":"Test Failed:"},{"type":"mrkdwn","text":"0"}`);
@@ -158,6 +159,7 @@ describe('slackUtils', () => {
             const result = slackUtils.slackMessage(mockFailStats, mockTimings, mockFail, [], 100);
             const duration = prettyms(mockTimings.completed - mockTimings.started)
             
+            expect(result).toContain(`Newman Test`);
             expect(result).toContain(`{"type":"mrkdwn","text":"Total Tests:"},{"type":"mrkdwn","text":"4"}`);
             expect(result).toContain(`{"type":"mrkdwn","text":"Test Passed:"},{"type":"mrkdwn","text":"2"}`);
             expect(result).toContain(`{"type":"mrkdwn","text":"Test Failed:"},{"type":"mrkdwn","text":"2"}`);
@@ -176,7 +178,23 @@ describe('slackUtils', () => {
             expect(result).toContain(`1. AssertionError - Status code is 500`);
             // should truncate error message
             expect(result).toContain(`Expected - response to have status code 500 but got 200 test more than 100 characters blah blah blah...`);
-        }); 
+        });
+
+        test('should contain custom author name when success', () => {
+            const result = slackUtils.slackMessage(mockPassStats, mockTimings, [], mockExecutions, 100, '', '', '#general', '', null, 'John Doe');
+
+            // should include channel name if given for channel override
+            expect(result).toContain(`"channel":"#general"`);
+            // change author
+            expect(result).toContain(`John Doe`);
+        });
+
+        test('should contain custom author name when failed', () => {
+            const result = slackUtils.slackMessage(mockFailStats, mockTimings, mockFail, [], 100, '', '', '#general', '', null, 'John Doe');
+
+            // changed author
+            expect(result).toContain(`John Doe`);
+        });
     });
 
     afterEach(() => {


### PR DESCRIPTION
# What?

An option `--reporter-slackmsg-authorName` to customize an author name for a Slack message.

# Why?

It's useful when different reports post to a same Slack channel.